### PR TITLE
Updated Feverstone ranges + Wildcraft Trees changes

### DIFF
--- a/biomes/assets/biomes/config/biomes2.json
+++ b/biomes/assets/biomes/config/biomes2.json
@@ -2425,6 +2425,15 @@
             ],
             "bioriver": "both"
         },
+        "coconuttree-*": {
+            "biorealm": [
+                "central palearctic",
+                "eastern palearctic",
+                "pacific palearctic",
+                "australasian"
+            ],
+            "bioriver": "both"
+        },
         "crimsonkingmaple": {
             "biorealm": [
                 "atlantic palearctic",
@@ -2747,7 +2756,7 @@
             ],
             "bioriver": "both"
         },
-        "salaux": {
+        "saxaul": {
             "biorealm": [
                 "central palearctic"
             ],

--- a/biomes/assets/biomes/config/biomes2.json
+++ b/biomes/assets/biomes/config/biomes2.json
@@ -1189,6 +1189,7 @@
         },
         "glowworms-*": {
             "biorealm": [
+                "australasian",
                 "oceanic"
             ],
             "bioriver": "both"

--- a/biomes/assets/biomes/patches/feverstonehorses.json
+++ b/biomes/assets/biomes/patches/feverstonehorses.json
@@ -6,8 +6,6 @@
     "value": {
       "*-draft": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -20,8 +18,6 @@
       },
       "*-donkey": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -38,8 +34,6 @@
     "value": {
       "*-draft": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -52,8 +46,6 @@
       },
       "*-donkey": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"

--- a/biomes/assets/biomes/patches/feverstonewilds.json
+++ b/biomes/assets/biomes/patches/feverstonewilds.json
@@ -8,7 +8,9 @@
       "*": {
         "biorealm": [
           "atlantic nearctic",
-          "pacific nearctic"
+          "pacific nearctic",
+          "atlantic palearctic",
+          "central palearctic"
         ]
       }
     },
@@ -27,7 +29,9 @@
       "*": {
         "biorealm": [
           "atlantic nearctic",
-          "pacific nearctic"
+          "pacific nearctic",
+          "atlantic palearctic",
+          "central palearctic"
         ]
       }
     },
@@ -45,18 +49,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
-          "atlantic neotropic",
-          "pacific neotropic",
-          "atlantic palearctic",
-          "central palearctic",
-          "eastern palearctic",
-          "pacific palearctic",
-          "eastern afrotropic",
-          "atlantic afrotropic",
-          "australasian",
-          "oceania"
+          "atlantic palearctic"
         ]
       }
     },
@@ -74,9 +67,8 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "atlantic palearctic",
-          "central palearctic"
+          "pacific nearctic",
+          "atlantic nearctic"
         ]
       }
     },
@@ -94,9 +86,8 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "atlantic palearctic",
-          "central palearctic"
+          "pacific nearctic",
+          "atlantic nearctic"
         ]
       }
     },
@@ -114,18 +105,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
-          "atlantic neotropic",
-          "pacific neotropic",
           "atlantic palearctic",
-          "central palearctic",
-          "eastern palearctic",
-          "pacific palearctic",
-          "eastern afrotropic",
-          "atlantic afrotropic",
-          "australasian",
-          "oceania"
         ]
       }
     },
@@ -143,8 +123,6 @@
     "value": {
       "*-draft": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -157,8 +135,6 @@
       },
       "*-donkey": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -179,8 +155,6 @@
     "value": {
       "*-draft": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -193,8 +167,6 @@
       },
       "*-donkey": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
           "atlantic palearctic",
           "central palearctic",
           "eastern palearctic"
@@ -244,7 +216,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "pacific palearctic",
+          "atlantic palearctic",
           "eastern afrotropic",
           "atlantic afrotropic"
         ]
@@ -264,18 +236,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
-          "atlantic neotropic",
-          "pacific neotropic",
-          "atlantic palearctic",
           "central palearctic",
-          "eastern palearctic",
-          "pacific palearctic",
-          "eastern afrotropic",
-          "atlantic afrotropic",
-          "australasian",
-          "oceania"
         ]
       }
     }
@@ -288,7 +249,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "pacific palearctic",
+          "atlantic palearctic",
           "eastern afrotropic",
           "atlantic afrotropic"
         ]
@@ -308,7 +269,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "pacific palearctic",
+          "atlantic palearctic",
           "eastern afrotropic",
           "atlantic afrotropic"
         ]
@@ -435,9 +396,7 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
-          "pacific nearctic",
-          "oceania"
+          "atlantic neotropic"
         ]
       }
     },
@@ -455,9 +414,18 @@
     "value": {
       "*": {
         "biorealm": [
-          "atlantic nearctic",
           "pacific nearctic",
-          "oceania"
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic",
+          "pacific neotropic",
+          "atlantic neotropic",
+          "atlantic afrotropic",
+          "eastern afrotropic",
+          "australasian",
+          "oceanic"
         ]
       }
     },


### PR DESCRIPTION
Removed horses from North America, added bison to Europe (Bison bonasus), cockatrice restricted to Atl. Pal, golem to Cen. Pal, faunling to Atl. Pal. Direwolves restricted to Pac and Atl Nea. Pac Nea removed from giraffes and ostriches, discus restricted to Atl. Neo.

Also added the missing coconut tree from Wildcraft trees, and fixed typo in saxaul trees