### PR TITLE
Fixed fox spawning for 1.19

### DIFF
--- a/biomes/assets/biomes/patches/vanilla-land.json
+++ b/biomes/assets/biomes/patches/vanilla-land.json
@@ -330,6 +330,34 @@
     }
   },
   {
+    "file": "game:entities/land/fox.json",
+    "op": "add",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "fox-*-red": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      },
+      "fox-*-arctic": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      }
+    }
+  },
+  {
     "file": "game:entities/land/grub.json",
     "op": "add",
     "path": "/attributes",


### PR DESCRIPTION
Retained references to older fox jsons, so should be backwards compatible.