### PR TITLE
Update for v1.21

### DIFF
--- a/biomes/assets/biomes/config/biomes2.json
+++ b/biomes/assets/biomes/config/biomes2.json
@@ -1482,7 +1482,8 @@
         "eastern afrotropic",
         "australasian",
         "oceanic"
-      ]
+      ],
+      "bioriver": "false"
     },
     "reefledge-*": {
       "biorealm": [
@@ -1498,7 +1499,8 @@
         "eastern afrotropic",
         "australasian",
         "oceanic"
-      ]
+      ],
+      "bioriver": "false"
     },
     "reefstructure-*": {
       "biorealm": [
@@ -1514,7 +1516,8 @@
         "eastern afrotropic",
         "australasian",
         "oceanic"
-      ]
+      ],
+      "bioriver": "false"
     },
     "aquatic-decor-*": {
       "biorealm": [
@@ -1530,7 +1533,8 @@
         "eastern afrotropic",
         "australasian",
         "oceanic"
-      ]
+      ],
+      "bioriver": "false"
     },
     "fern-cinnamonfern": {
       "biorealm": [

--- a/biomes/assets/biomes/config/biomes2.json
+++ b/biomes/assets/biomes/config/biomes2.json
@@ -1468,6 +1468,70 @@
       ],
       "bioriver": "false"
     },
+    "reefblock-*": {
+      "biorealm": [
+        "pacific nearctic",
+        "atlantic nearctic",
+        "atlantic palearctic",
+        "central palearctic",
+        "eastern palearctic",
+        "pacific palearctic",
+        "pacific neotropic",
+        "atlantic neotropic",
+        "atlantic afrotropic",
+        "eastern afrotropic",
+        "australasian",
+        "oceanic"
+      ]
+    },
+    "reefledge-*": {
+      "biorealm": [
+        "pacific nearctic",
+        "atlantic nearctic",
+        "atlantic palearctic",
+        "central palearctic",
+        "eastern palearctic",
+        "pacific palearctic",
+        "pacific neotropic",
+        "atlantic neotropic",
+        "atlantic afrotropic",
+        "eastern afrotropic",
+        "australasian",
+        "oceanic"
+      ]
+    },
+    "reefstructure-*": {
+      "biorealm": [
+        "pacific nearctic",
+        "atlantic nearctic",
+        "atlantic palearctic",
+        "central palearctic",
+        "eastern palearctic",
+        "pacific palearctic",
+        "pacific neotropic",
+        "atlantic neotropic",
+        "atlantic afrotropic",
+        "eastern afrotropic",
+        "australasian",
+        "oceanic"
+      ]
+    },
+    "aquatic-decor-*": {
+      "biorealm": [
+        "pacific nearctic",
+        "atlantic nearctic",
+        "atlantic palearctic",
+        "central palearctic",
+        "eastern palearctic",
+        "pacific palearctic",
+        "pacific neotropic",
+        "atlantic neotropic",
+        "atlantic afrotropic",
+        "eastern afrotropic",
+        "australasian",
+        "oceanic"
+      ]
+    },
     "fern-cinnamonfern": {
       "biorealm": [
         "atlantic nearctic",

--- a/biomes/assets/biomes/patches/vanilla-air.json
+++ b/biomes/assets/biomes/patches/vanilla-air.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "game:entities/air/beemob.json",
+    "file": "game:entities/animal/invertebrate/beemob.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",

--- a/biomes/assets/biomes/patches/vanilla-butterflies.json
+++ b/biomes/assets/biomes/patches/vanilla-butterflies.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "game:entities/air/butterfly.json",
+    "file": "game:entities/animal/invertebrate/butterfly.json",
     "op": "addmerge",
     "path": "/attributesByType",
     "side": "Server",

--- a/biomes/assets/biomes/patches/vanilla-land.json
+++ b/biomes/assets/biomes/patches/vanilla-land.json
@@ -1,11 +1,11 @@
 [
   {
-    "file": "game:entities/land/bear.json",
+    "file": "game:entities/animal/mammal/bear-adult.json",
     "op": "addmerge",
     "path": "/attributesByType",
     "side": "Server",
     "value": {
-      "*-black": {
+      "bear-black-*": {
         "biorealm": [
           "atlantic nearctic",
           "central palearctic",
@@ -14,7 +14,7 @@
           "pacific palearctic"
         ]
       },
-      "*-brown": {
+      "bear-brown-*": {
         "biorealm": [
           "atlantic nearctic",
           "atlantic palearctic",
@@ -24,12 +24,12 @@
           "pacific palearctic"
         ]
       },
-      "*-panda": {
+      "bear-panda-*": {
         "biorealm": [
           "eastern palearctic"
         ]
       },
-      "*-polar": {
+      "bear-polar-*": {
         "biorealm": [
           "atlantic nearctic",
           "atlantic palearctic",
@@ -39,7 +39,7 @@
           "pacific palearctic"
         ]
       },
-      "*-sun": {
+      "bear-sun-*": {
         "biorealm": [
           "eastern palearctic",
           "pacific palearctic"
@@ -47,8 +47,8 @@
       }
     }
   },
-    {
-    "file": "game:entities/land/hooved/deer.json",
+  {
+    "file": "game:entities/animal/mammal/hooved/deer-adult.json",
     "op": "addmerge",
     "path": "/attributesByType",
     "side": "Server",
@@ -129,7 +129,88 @@
     }
   },
   {
-    "file": "game:entities/land/hooved/goat.json",
+    "file": "game:entities/animal/mammal/hooved/deer-baby.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "deer-whitetail-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "pacific neotropic",
+          "atlantic neotropic"
+        ]
+      },
+      "deer-redbrocket-*": {
+        "biorealm": [
+          "pacific neotropic",
+          "atlantic neotropic"
+        ]
+      },
+      "deer-marsh-*": {
+        "biorealm": [
+          "atlantic neotropic"
+        ]
+      },
+      "deer-caribou-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      },
+      "deer-water-*": {
+        "biorealm": [
+          "eastern palearctic"
+        ]
+      },
+      "deer-pudu-*": {
+        "biorealm": [
+          "pacific neotropic"
+        ]
+      },
+      "deer-elk-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "central palearctic",
+          "eastern palearctic"
+        ]
+      },
+      "deer-taruca-*": {
+        "biorealm": [
+          "pacific neotropic"
+        ]
+      },
+      "deer-chital-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "deer-guemal-*": {
+        "biorealm": [
+          "pacific neotropic"
+        ]
+      },
+      "deer-pampas-*": {
+        "biorealm": [
+          "atlantic neotropic"
+        ]
+      },
+      "deer-fallow-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/mammal/hooved/goat-adult.json",
     "op": "addmerge",
     "path": "/attributesByType",
     "side": "Server",
@@ -198,7 +279,76 @@
     }
   },
   {
-    "file": "game:entities/land/hooved/moose.json",
+    "file": "game:entities/animal/mammal/hooved/goat-baby.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "goat-angora-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "goat-ibexalp-*": {
+        "biorealm": [
+          "atlantic palearctic"
+        ]
+      },
+      "goat-ibexnub-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic"
+        ]
+      },
+      "goat-markhor-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "goat-mountain-*": {
+        "biorealm": [
+          "pacific nearctic"
+        ]
+      },
+      "goat-muskox-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific nearctic",
+          "pacific palearctic"
+        ]
+      },
+      "goat-nubian-*": {
+        "biorealm": [
+          "atlantic palearctic"
+        ]
+      },
+      "goat-sirohi-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "goat-takingold-*": {
+        "biorealm": [
+          "eastern palearctic"
+        ]
+      },
+      "goat-turdag-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "goat-valais-*": {
+        "biorealm": [
+          "atlantic palearctic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/mammal/hooved/moose-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -213,70 +363,55 @@
     }
   },
   {
-    "file": "game:entities/land/chicken-baby.json",
+    "file": "game:entities/animal/mammal/hooved/moose-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/chicken-hen.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/chicken-rooster.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/fox.json",
-    "op": "addmerge",
-    "path": "/attributesByType",
-    "side": "server",
     "value": {
       "biorealm": [
         "pacific nearctic",
         "atlantic nearctic",
         "atlantic palearctic",
         "central palearctic",
+        "eastern palearctic"
+      ]
+    }
+  },
+  {
+    "file": "game:entities/animal/bird/chicken-adult.json",
+    "op": "addmerge",
+    "path": "/attributes",
+    "side": "Server",
+    "value": {
+      "biorealm": [
+        "atlantic palearctic",
+        "central palearctic",
         "eastern palearctic",
         "pacific palearctic"
       ]
     }
   },
   {
-    "file": "game:entities/land/fox.json",
+    "file": "game:entities/animal/bird/chicken-baby.json",
     "op": "addmerge",
-    "path": "/attributesByType",
+    "path": "/attributes",
     "side": "Server",
     "value": {
-      "fox-*-red": {
+      "biorealm": [
+        "atlantic palearctic",
+        "central palearctic",
+        "eastern palearctic",
+        "pacific palearctic"
+      ]
+    }
+  },
+  {
+    "file": "game:entities/animal/mammal/fox-adult.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "server",
+    "value": {
+      "fox-red-*": {
         "biorealm": [
           "pacific nearctic",
           "atlantic nearctic",
@@ -286,7 +421,7 @@
           "pacific palearctic"
         ]
       },
-      "fox-*-arctic": {
+      "fox-arctic-*": {
         "biorealm": [
           "pacific nearctic",
           "atlantic nearctic",
@@ -299,7 +434,35 @@
     }
   },
   {
-    "file": "game:entities/land/grub.json",
+    "file": "game:entities/animal/mammal/fox-baby.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "server",
+    "value": {
+      "fox-red-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      },
+      "fox-arctic-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/invertebrate/grub.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -321,7 +484,7 @@
     }
   },
   {
-    "file": "game:entities/land/gazelle.json",
+    "file": "game:entities/animal/mammal/hooved/gazelle-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -336,61 +499,121 @@
     }
   },
   {
-    "file": "game:entities/land/hare-baby.json",
+    "file": "game:entities/animal/mammal/hooved/gazelle-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
     "value": {
       "biorealm": [
-        "pacific nearctic",
-        "atlantic nearctic",
         "atlantic palearctic",
         "central palearctic",
         "eastern palearctic",
-        "pacific palearctic",
         "atlantic afrotropic",
         "eastern afrotropic"
       ]
     }
   },
   {
-    "file": "game:entities/land/hare-female.json",
+    "file": "game:entities/animal/mammal/hare-adult.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "hare-arctic-*": {
+        "biorealm": [
+          "atlantic nearctic"
+        ]
+      },
+      "hare-cape-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic",
+          "atlantic afrotropic",
+          "eastern afrotropic"
+        ]
+      },
+      "hare-european-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic"
+        ]
+      },
+      "hare-indian-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "hare-jackblack-*": {
+        "biorealm": [
+          "pacific nearctic"
+        ]
+      },
+      "hare-scrub-*": {
+        "biorealm": [
+          "atlantic afrotropic",
+          "eastern afrotropic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/mammal/hare-baby.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "hare-arctic-*": {
+        "biorealm": [
+          "atlantic nearctic"
+        ]
+      },
+      "hare-cape-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic",
+          "atlantic afrotropic",
+          "eastern afrotropic"
+        ]
+      },
+      "hare-european-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "central palearctic"
+        ]
+      },
+      "hare-indian-*": {
+        "biorealm": [
+          "central palearctic"
+        ]
+      },
+      "hare-jackblack-*": {
+        "biorealm": [
+          "pacific nearctic"
+        ]
+      },
+      "hare-scrub-*": {
+        "biorealm": [
+          "atlantic afrotropic",
+          "eastern afrotropic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/mammal/hyena-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
     "value": {
       "biorealm": [
-        "pacific nearctic",
-        "atlantic nearctic",
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic",
         "atlantic afrotropic",
+        "atlantic palearctic",
         "eastern afrotropic"
       ]
     }
   },
   {
-    "file": "game:entities/land/hare-male.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "pacific nearctic",
-        "atlantic nearctic",
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic",
-        "atlantic afrotropic",
-        "eastern afrotropic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/hyena-female.json",
+    "file": "game:entities/animal/mammal/hyena-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -403,33 +626,7 @@
     }
   },
   {
-    "file": "game:entities/land/hyena-male.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic afrotropic",
-        "atlantic palearctic",
-        "eastern afrotropic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/hyena-pup.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic afrotropic",
-        "atlantic palearctic",
-        "eastern afrotropic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/pig-wild-female.json",
+    "file": "game:entities/animal/mammal/hooved/pig-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -445,7 +642,7 @@
     }
   },
   {
-    "file": "game:entities/land/pig-wild-male.json",
+    "file": "game:entities/animal/mammal/hooved/pig-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -459,21 +656,7 @@
     }
   },
   {
-    "file": "game:entities/land/pig-wild-piglet.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "Server",
-    "value": {
-      "biorealm": [
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/raccoon-female.json",
+    "file": "game:entities/animal/mammal/raccoon-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",
@@ -485,7 +668,7 @@
     }
   },
   {
-    "file": "game:entities/land/raccoon-male.json",
+    "file": "game:entities/animal/mammal/raccoon-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",
@@ -497,19 +680,7 @@
     }
   },
   {
-    "file": "game:entities/land/raccoon-pup.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "server",
-    "value": {
-      "biorealm": [
-        "pacific nearctic",
-        "atlantic nearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/sheep-bighorn-female.json",
+    "file": "game:entities/animal/mammal/hooved/sheep-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",
@@ -520,7 +691,7 @@
     }
   },
   {
-    "file": "game:entities/land/sheep-bighorn-lamb.json",
+    "file": "game:entities/animal/mammal/hooved/sheep-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",
@@ -531,18 +702,7 @@
     }
   },
   {
-    "file": "game:entities/land/sheep-bighorn-male.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "server",
-    "value": {
-      "biorealm": [
-        "pacific nearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/wolf-female.json",
+    "file": "game:entities/animal/mammal/wolf-adult.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",
@@ -558,23 +718,7 @@
     }
   },
   {
-    "file": "game:entities/land/wolf-male.json",
-    "op": "addmerge",
-    "path": "/attributes",
-    "side": "server",
-    "value": {
-      "biorealm": [
-        "pacific nearctic",
-        "atlantic nearctic",
-        "atlantic palearctic",
-        "central palearctic",
-        "eastern palearctic",
-        "pacific palearctic"
-      ]
-    }
-  },
-  {
-    "file": "game:entities/land/wolf-pup.json",
+    "file": "game:entities/animal/mammal/wolf-baby.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "server",

--- a/biomes/assets/biomes/patches/vanilla-water.json
+++ b/biomes/assets/biomes/patches/vanilla-water.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "game:entities/water/bass.json",
+    "file": "game:entities/animal/fish/bass.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",
@@ -22,7 +22,7 @@
     }
   },
   {
-    "file": "game:entities/water/salmon.json",
+    "file": "game:entities/animal/fish/salmon.json",
     "op": "addmerge",
     "path": "/attributes",
     "side": "Server",

--- a/biomes/assets/biomes/patches/vanilla-water.json
+++ b/biomes/assets/biomes/patches/vanilla-water.json
@@ -33,5 +33,232 @@
         "pacific palearctic"
       ]
     }
+  },
+  {
+    "file": "game:entities/animal/fish/saltwater-adult.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "fish-saltwater-amberjack-yellowtail-*": {
+        "biorealm": [
+          "pacific neotropic",
+          "atlantic neotropic",
+          "atlantic afrotropic",
+          "eastern afrotropic",
+          "australasian",
+          "oceanic"
+        ]
+      },
+      "fish-saltwater-barracuda-great-*": {
+        "biorealm": [
+          "pacific neotropic",
+          "atlantic neotropic",
+          "atlantic afrotropic",
+          "eastern afrotropic",
+          "australasian"
+        ]
+      },
+      "fish-saltwater-bream-sea-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic neotropic",
+          "atlantic palearctic"
+        ]
+      },
+      "fish-saltwater-coelacanth-common-*": {
+        "biorealm": [
+          "central palearctic",
+          "eastern afrotropic"
+        ]
+      },
+      "fish-saltwater-grouper-black-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic neotropic"
+        ]
+      },
+      "fish-saltwater-gurnard-cape-*": {
+        "biorealm": [
+          "atlantic afrotropic",
+          "eastern afrotropic"
+        ]
+      },
+      "fish-saltwater-haddock-common-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic palearctic"
+        ]
+      },
+      "fish-saltwater-hake-silver-*": {
+        "biorealm": [
+          "atlantic nearctic"
+        ]
+      },
+      "fish-saltwater-herring-atlantic-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic palearctic"
+        ]
+      },
+      "fish-saltwater-mackerel-atlantic-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic palearctic",
+          "central palearctic"
+        ]
+      },
+      "fish-saltwater-mahi-mahi-common-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic nearctic",
+          "pacific neotropic",
+          "atlantic neotropic",
+          "atlantic afrotropic",
+          "eastern afrotropic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      },
+      "fish-saltwater-perch-pacific-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "pacific palearctic",
+          "eastern palearctic"
+        ]
+      },
+      "fish-saltwater-pollock-alaska-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "pacific palearctic",
+          "eastern palearctic"
+        ]
+      },
+      "fish-saltwater-salmon-pink-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "eastern palearctic",
+          "pacific palearctic"
+        ]
+      },
+      "fish-saltwater-snapper-red-*": {
+        "biorealm": [
+          "atlantic nearctic"
+        ]
+      },
+      "fish-saltwater-sturgeon-atlantic-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic palearctic"
+        ]
+      },
+      "fish-saltwater-tuna-skipjack-*": {
+        "biorealm": [
+          "pacific palearctic",
+          "eastern palearctic",
+          "central palearctic",
+          "eastern afrotropic",
+          "atlantic palearctic",
+          "atlantic nearctic",
+          "atlantic neotropic",
+          "pacific nearctic"
+        ]
+      },
+      "fish-saltwater-wolf-bering-*": {
+        "biorealm": [
+          "pacific palearctic",
+          "eastern palearctic",
+          "pacific nearctic"
+        ]
+      },
+      "fish-saltwater-wreckfish-atlantic-*": {
+        "biorealm": [
+          "atlantic palearctic",
+          "atlantic afrotropic",
+          "atlantic neotropic",
+          "australasian",
+          "oceanic"
+        ]
+      }
+    }
+  },
+  {
+    "file": "game:entities/animal/fish/reef-adult.json",
+    "op": "addmerge",
+    "path": "/attributesByType",
+    "side": "Server",
+    "value": {
+      "fish-reef-angel-bicolor-*": {
+        "biorealm": [
+          "eastern afrotropic",
+          "pacific palearctic",
+          "australasian",
+          "oceanic"
+        ]
+      },
+      "fish-reef-butterfly-copperband-*": {
+        "biorealm": [
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic",
+          "australasian"
+        ]
+      },
+      "fish-reef-butterfly-blackwedged-*": {
+        "biorealm": [
+          "central palearctic",
+          "eastern afrotropic"
+        ]
+      },
+      "fish-reef-clown-*-*": {
+        "biorealm": [
+          "eastern afrotropic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic",
+          "australasian"
+        ]
+      },
+      "fish-reef-puffer-longspine-*": {
+        "biorealm": [
+          "pacific nearctic",
+          "atlantic afrotropic",
+          "eastern afrotropic",
+          "central palearctic",
+          "eastern palearctic",
+          "pacific palearctic",
+          "australasian"
+        ]
+      },
+      "fish-reef-tang-banded-*": {
+        "biorealm": [
+          "eastern afrotropic",
+          "central palearctic",
+          "eastern palearctic",
+          "australasian"
+        ]
+      },
+      "fish-reef-tang-powderblue-*": {
+        "biorealm": [
+          "eastern afrotropic",
+          "central palearctic"
+        ]
+      },
+      "fish-reef-trigger-titan-*": {
+        "biorealm": [
+          "eastern afrotropic",
+          "central palearctic",
+          "eastern palearctic",
+          "australasian"
+        ]
+      },
+      "fish-reef-wrasse-creole-*": {
+        "biorealm": [
+          "atlantic nearctic",
+          "atlantic neotropic"
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
1.21 changed the folder structure of vanilla animals, which broke the mod. This PR fixes that, as well as the following changes.

- Hares are now sorted into biomes, based on habitat maps found on Wikipedia. Example: https://en.wikipedia.org/wiki/European_hare
- The new saltwater and reef fish have been added. I did my best on sorting them, but I had a hard time finding detailed habitat information for many of them. You may want to review them. Or even consider putting all reef fish in all biomes to avoid reefs feeling too empty. 
- Added the missing reef blocks such as `reefblock-*`, `reefledge-*`, `aquatic-decor-*`, etc.

There are a few unconfigured entities.

- `game:butterfly-reedbutterfly`
- `game:skeletonarm`
- `game:skeletonwithloot`

I can't find them in the creative menu though so I assume they're unused. The skeletons should probably be looked into though, the game files imply they have something to do with the Resonance Archives.